### PR TITLE
Delay as code

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,17 +6,23 @@
   "build-depends": [
   ],
   "depends": [
+    "Test::META"
   ],
   "description": "Retry action",
   "license": "Artistic-2.0",
+  "meta-version": "0",
   "name": "Retry",
   "perl": "6.d",
   "provides": {
     "Retry": "lib/Retry.rakumod"
   },
+  "raku": null,
   "resources": [
   ],
   "source-url": "https://github.com/hythm7/Retry.git",
+  "support": {
+    "source": null
+  },
   "tags": [
     "retry"
   ],

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ SYNOPSIS
 use Retry;
 
 retry { action }, :4max, :2delay;
+
+retry { say 'trying!'; die }, :max(-1), :delay({ constant @fib = 0, 1, *+* ... *; @fib[$++] });
+
 ```
 
 DESCRIPTION
@@ -19,7 +22,7 @@ Retry is a module that exports `retry` sub which takes a `Block` to retry execut
 
 `max` defaults to `4`. sets the max number of retries. `-∞ ≤ max < 0` to retry forever.
 
-`delay` defaults to `0.2`. sets the delay between retries. delay doubles with every retry.
+`delay` defaults to `0.2`. sets the delay between retries. The delay doubles with every retry. Use a `Code` object to provide your own stepping. Each call must return a `Real`.
 
 AUTHOR
 ======

--- a/lib/Retry.rakumod
+++ b/lib/Retry.rakumod
@@ -1,6 +1,6 @@
 unit module Retry:ver<0.0.2>:auth<github:hythm7>;
 
-sub retry ( &action, Int:D :$max is copy = 4, Real:D :$delay is copy = 0.2 ) is export {
+multi sub retry ( &action, Int:D :$max is copy = 4, Real:D :$delay is copy = 0.2 ) is export {
 
   loop {
 
@@ -13,6 +13,24 @@ sub retry ( &action, Int:D :$max is copy = 4, Real:D :$delay is copy = 0.2 ) is 
     sleep $delay;
 
     $delay *= 2;
+    $max   -= 1;
+
+  }
+
+}
+
+multi sub retry ( &action, Int:D :$max is copy = 4, :&delay ) is export {
+
+  loop {
+
+    my $result = try action();
+
+    return $result unless $!;
+
+    $!.rethrow if $max == 0;
+
+    sleep delay;
+
     $max   -= 1;
 
   }

--- a/t/01-basic.rakutest
+++ b/t/01-basic.rakutest
@@ -2,23 +2,45 @@ use Test;
 use Retry;
 
 
-plan 2;
+plan 4;
 
-my $i = 0;
+sub eventually-lives {
 
-lives-ok { retry( {
+  sub {
+    die unless $++ > 0;
 
-  loop {
-
-        last if $i == 1;
-        $i += 1;
-        die;
+    True
   }
 
-  $i;
+}
 
-} ) }, 'retry success in second attempt';
+sub always-dies {
 
-dies-ok { retry( { die }, :1max ) }, 'dies when always fail';
+    sub {
+        die;
+    }
+
+}
+
+
+lives-ok {
+
+  retry eventually-lives
+
+}, 'retry success in second attempt';
+
+
+dies-ok { retry( always-dies, :1max ) }, 'dies when always fail';
+
+
+lives-ok {
+    retry eventually-lives, :delay({ (1/10..3/10).pick });
+}, 'retry delayed by Code';
+
+
+dies-ok {
+    retry always-dies, :delay({ 0 });
+}, 'retry delayed by Code';
+
 
 done-testing;

--- a/t/meta.t
+++ b/t/meta.t
@@ -1,0 +1,9 @@
+use v6;
+
+use lib 'lib';
+use Test;
+use Test::META;
+
+meta-ok;
+
+done-testing;


### PR DESCRIPTION
Doubling the delay is a good default. For large or even infinite retries it becomes unpracticle quite quickly. By allowing a Callable the user got the most freedom.